### PR TITLE
Fix for mis-aligned timestamp on tweets

### DIFF
--- a/twitter.css
+++ b/twitter.css
@@ -275,7 +275,10 @@ body {
 }
 ._timestamp {
 	position: absolute;
-  right: 10px;
+	right: 15px;
+}
+span.metadata {
+	margin-left: 180px;
 }
 
 /* Tweet actions */


### PR DESCRIPTION
Moved the timestamp back to the right.
