### PR TITLE
Fix for new three-col wrapper

### DIFF
--- a/twitter.css
+++ b/twitter.css
@@ -262,6 +262,10 @@ s, .pretty-link:hover s, .pretty-link:focus s, .stream-item-activity-me .latest-
 .wrapper {
   width: 894px !important;
 }
+/* Three-column wrapper */
+body.three-col .wrapper {
+  width: 1190px !important;
+}
 /* Reiterate to keep permalinks from becoming too wide */
 .wrapper-permalink {
   width: 592px !important;


### PR DESCRIPTION
Hey @mdo,

Thanks for making my twitter pretty. I opened up the site today to find this:

![screen shot 2014-04-16 at 9 51 38 am](https://cloud.githubusercontent.com/assets/287268/2720380/65ca035e-c56e-11e3-89b0-b842d9c675ce.png)

After poking around in inspector, I noticed that you included the rule:

``` css
.wrapper {
  width: 894px !important;
}
```

But in incognito mode, the vanilla twitter.com wanted to display wrapper with a width of **1190px**, thanks to the new `.three-col` class on the body. This PR includes a small change to accommodate this. Here's an updated screenshot:

![screen shot 2014-04-16 at 9 51 23 am](https://cloud.githubusercontent.com/assets/287268/2720408/bfb339ee-c56e-11e3-8f6f-953d58cd0c50.png)

Personally, I don't really like the new three-column layout, so on my machine I simply changed the `margin-right` on `.content-main` to **0**, effectively hiding the third column. That's just personal taste, though.
