### PR TITLE
Prevent resizing profile hovercards

### DIFF
--- a/twitter.css
+++ b/twitter.css
@@ -597,6 +597,12 @@ body.three-col .wrapper {
  * Profile page
  */
 
+ /* Prevent below changes to profile headers from applying to hovercards */
+ .hovercard.profile-card.profile-header {
+   padding-top: 0px !important;
+   width: 290px !important;
+ }
+
 /* Enable header image to be positioned absolutely so that it overlays the module border */
 .profile-card.profile-header {
   position: relative !important;


### PR DESCRIPTION
It would appear that profile cards on click are no longer a thing, replaced by the new hovercards. I'm not sure though, so I opted to prevent changes to the hovercards rather than remove the customization to profile cards altogether. 

Before:
![2015-07-30_18-07-12](https://cloud.githubusercontent.com/assets/904055/8996494/5f18769a-36e6-11e5-8028-cee6de56b37c.png)

After:
![2015-07-30_18-09-10](https://cloud.githubusercontent.com/assets/904055/8996495/65486426-36e6-11e5-816a-c2623bcdaaa8.png)
